### PR TITLE
It fails if passed function has no parameters: fixed

### DIFF
--- a/lib/introspect/introspect.js
+++ b/lib/introspect/introspect.js
@@ -2,6 +2,10 @@ var argumentsRegExp = /\(([\s\S]*?)\)/;
 var replaceRegExp = /[ ,\n\r\t]+/;
 
 module.exports = function (fn) {
-  var fnArguments = argumentsRegExp.exec(fn)[1].trim();
+  var fnArguments = argumentsRegExp.exec(fn)
+  if( fnArguments === null){
+    return []
+  }
+  fnArguments = fnArguments[1].trim();
   return fnArguments.split(replaceRegExp);
 };

--- a/test/introspect-test.js
+++ b/test/introspect-test.js
@@ -22,6 +22,9 @@ vows.describe('introspect/main').addBatch({
         for(var b = 0; b < 1000; b ++) { }
         if (a == 5) { }
       }), ['foo', 'bar', 'callback']);
+    },
+    'with no arguments': function () {
+      assert.deepEqual(introspect( function () {} ), []);
     }
   }
 }).export(module);


### PR DESCRIPTION
There are cases when you use introspect where you try to look at a function with no parameters. It that case introspect fails because exec return null and you where trying to access element [1] of null.
