### PR TITLE
Added es6 classes constructor introspection

### DIFF
--- a/lib/introspect/introspect.js
+++ b/lib/introspect/introspect.js
@@ -1,5 +1,5 @@
 var isClassRegExp = /class/;
-var hasCtorRegExp = /constructor/;
+var hasCtorRegExp = /constructor\s*\(/;
 var argumentsRegExp = /\(([\s\S]*?)\)/;
 var classArgumentsRegExp = /constructor\s*\(([\s\S]*?)\)/;
 var replaceRegExp = /[ ,\n\r\t]+/;

--- a/lib/introspect/introspect.js
+++ b/lib/introspect/introspect.js
@@ -1,11 +1,23 @@
-var argumentsRegExp = /\(([\s\S]*?)\)/;
 var isClassRegExp = /class/;
+var hasCtorRegExp = /constructor/;
+var argumentsRegExp = /\(([\s\S]*?)\)/;
 var classArgumentsRegExp = /constructor\s*\(([\s\S]*?)\)/;
 var replaceRegExp = /[ ,\n\r\t]+/;
 
+function findFirstCtor(fn){
+  while (!hasCtorRegExp.test(fn) && isClassRegExp.test(fn)){
+    fn = Object.getPrototypeOf(fn);
+  }
+  return fn;
+}
+
 module.exports = function (fn) {
   var isClass = isClassRegExp.test(fn);
-  var regEx = isClass ? classArgumentsRegExp : argumentsRegExp;
+  var regEx = argumentsRegExp;
+  if (isClass){
+    regEx = classArgumentsRegExp;
+    fn = findFirstCtor(fn);
+  }
   var results = regEx.exec(fn);
   if (null === results) return [];
   var fnArguments = results[1].trim();

--- a/lib/introspect/introspect.js
+++ b/lib/introspect/introspect.js
@@ -1,8 +1,14 @@
 var argumentsRegExp = /\(([\s\S]*?)\)/;
+var isClassRegExp = /class/;
+var classArgumentsRegExp = /constructor\s*\(([\s\S]*?)\)/;
 var replaceRegExp = /[ ,\n\r\t]+/;
 
 module.exports = function (fn) {
-  var fnArguments = argumentsRegExp.exec(fn)[1].trim();
+  var isClass = isClassRegExp.test(fn);
+  var regEx = isClass ? classArgumentsRegExp : argumentsRegExp;
+  var results = regEx.exec(fn);
+  if (null === results) return [];
+  var fnArguments = results[1].trim();
   if (0 === fnArguments.length) return [];
   return fnArguments.split(replaceRegExp);
 };

--- a/test/introspect-test.js
+++ b/test/introspect-test.js
@@ -4,6 +4,16 @@ var
   assert = require('assert'),
   introspect = require('../lib/introspect/introspect');
 
+class ClassWithCtorFirst {
+  constructor(a, b) {}
+  method(c, d) {}
+}
+
+class ClassWithMethodFirst {
+  method(c, d) {}
+  constructor(a, b) {}
+}
+
 vows.describe('introspect/main').addBatch({
   'introspect should success': {
     'without spaces': function () {
@@ -39,9 +49,23 @@ vows.describe('introspect/main').addBatch({
     'with class with ctor with arguments': function () {
       assert.deepEqual(introspect(class CtorWithArgs{ constructor(foo,bar,callback){  }}), ['foo','bar','callback']);
     },
-    'with class with ineherited ctor': function () {
+    'with class with inherited ctor': function () {
       class CtorWithArgs{ constructor(foo,bar,callback){  }}
       assert.deepEqual(introspect(class InheritedCtor extends CtorWithArgs{}), ['foo','bar','callback']);
+    },
+    'with class with method after ctor': function () {
+      assert.deepEqual(introspect(ClassWithCtorFirst), ['a','b']);
+    },
+    'with class with method before ctor': function () {
+      assert.deepEqual(introspect(ClassWithMethodFirst), ['a','b']);
+    },
+    'with class unbound method': function () {
+      assert.deepEqual(introspect(ClassWithCtorFirst.prototype.method), ['c','d']);
+      assert.deepEqual(introspect(ClassWithMethodFirst.prototype.method), ['c','d']);
+    },
+    'with class bound method': function () {
+      assert.deepEqual(introspect(new ClassWithCtorFirst().method), ['c','d']);
+      assert.deepEqual(introspect(new ClassWithMethodFirst().method), ['c','d']);
     }
   }
 }).export(module);

--- a/test/introspect-test.js
+++ b/test/introspect-test.js
@@ -1,3 +1,4 @@
+'use strict';
 var
   vows = require('vows'),
   assert = require('assert'),
@@ -26,6 +27,17 @@ vows.describe('introspect/main').addBatch({
     'with no arguments': function () {
       assert.deepEqual(introspect(function () {}), []);
       assert.deepEqual(introspect(function ( ) {   }), []);
+    },
+    'with class with no ctor': function () {
+      assert.deepEqual(introspect(class NoCtor{}), []);
+      assert.deepEqual(introspect(class NoCtor2 {    }), []);
+    },
+    'with class with ctor with no arguments': function () {
+      assert.deepEqual(introspect(class EmptyCtor{ constructor(){}}), []);
+      assert.deepEqual(introspect(class EmptyCtor2{ constructor(     ){  }}), []);
+    },
+    'with class with ctor with arguments': function () {
+      assert.deepEqual(introspect(class CtorWithArgs{ constructor(foo,bar,callback){  }}), ['foo','bar','callback']);
     }
   }
 }).export(module);

--- a/test/introspect-test.js
+++ b/test/introspect-test.js
@@ -38,6 +38,10 @@ vows.describe('introspect/main').addBatch({
     },
     'with class with ctor with arguments': function () {
       assert.deepEqual(introspect(class CtorWithArgs{ constructor(foo,bar,callback){  }}), ['foo','bar','callback']);
+    },
+    'with class with ineherited ctor': function () {
+      class CtorWithArgs{ constructor(foo,bar,callback){  }}
+      assert.deepEqual(introspect(class InheritedCtor extends CtorWithArgs{}), ['foo','bar','callback']);
     }
   }
 }).export(module);


### PR DESCRIPTION
This allows introspection of the new native es6 classes.
Running the tests now requires a node version that allows es6 classes, so v0.12+ with the --harmony flag.
